### PR TITLE
Make code compatible with Python 2.7 and Python >=3.6

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,18 +4,16 @@ dependencies:
   pre:
     # setup test env/isolation
     - mkdir -p $CIRCLE_TEST_REPORTS/flake8
-    - mkdir -p $CIRCLE_TEST_REPORTS/nosetests
-    - mkdir -p $CIRCLE_TEST_REPORTS/coverage
     # install actual dependencies
     - pip install --upgrade pip
     - pip install --upgrade -r dev-requirements.txt
+
+  override:
+    # tell tox to use pyenv
+    - pyenv local 2.7.12 3.6.1
 
 test:
   override:
     # only diff branch changes
     - git diff master -- '*.py' | flake8 --diff --output-file=$CIRCLE_TEST_REPORTS/flake8/report.txt scrapyjobparameters/
-    - >
-      nosetests -v --with-timer
-      --with-xunit --xunit-file=$CIRCLE_TEST_REPORTS/nosetests/tests.xml
-      --with-coverage --cover-min-percentage=37 --cover-html --cover-erase --cover-package=scrapyjobparameters
-      --cover-html-dir=$CIRCLE_TEST_REPORTS/coverage/scrapyjobparameters
+    - tox

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,10 @@
 -r requirements.txt
 
+flake8==3.5.0
 ipdb
+isort==4.2.15
 nose-timer==0.7.0
 nose==1.3.7
 nose-cov==1.6
-isort==4.2.15
+tox==3.0.0
+tox-pyenv==1.1.0

--- a/scrapyjobparameters/__init__.py
+++ b/scrapyjobparameters/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
 __package__ = 'scrapyjobparameters'
-__version__ = '0.1.8'
+__version__ = '0.1.9'

--- a/scrapyjobparameters/extension.py
+++ b/scrapyjobparameters/extension.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 import datetime as dt
 import logging
 import os

--- a/scrapyjobparameters/extension.py
+++ b/scrapyjobparameters/extension.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
 import datetime as dt
 import logging
 import os

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 # as inspired by https://github.com/kennethreitz/setup.py
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 import codecs
 import os
 from setuptools import setup

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 
 # as inspired by https://github.com/kennethreitz/setup.py
 
+from __future__ import absolute_import
 import codecs
 import os
 from setuptools import setup

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
 import os
 import datetime as dt
 import unittest

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 import os
 import datetime as dt
 import unittest

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,28 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+# Choose your Python versions. They have to be available
+# on the system the tests are run on.
+envlist = py27, py36
+
+# Tell tox to not require a setup.py file
+skipsdist = True
+
+[testenv]
+passenv = * 
+whitelist_externals = mkdir
+deps =
+  -rdev-requirements.txt
+  -rrequirements.txt
+
+commands=
+  mkdir -p {env:CIRCLE_TEST_REPORTS:}/tests/{envname}/nosetests
+  mkdir -p {env:CIRCLE_TEST_REPORTS:}/tests/{envname}/coverage
+
+  nosetests {posargs:-v --with-timer \
+  --with-xunit --xunit-file={env:CIRCLE_TEST_REPORTS:}/tests/{envname}/nosetests/tests.xml \
+  --with-coverage --cover-min-percentage=37 --cover-html --cover-erase --cover-package=scrapyjobparameters \
+  --cover-html-dir={env:CIRCLE_TEST_REPORTS:}/tests/{envname}/coverage/scrapyjobparameters}


### PR DESCRIPTION
1- Run modernize command to turn py2 code into a six-compatible code (py27 + py36)
2- Edit result manually
3- Test code and dependencies installation with `tox` command for both python versions